### PR TITLE
opengl-3.3 to develop

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -22,8 +22,8 @@ int main()
         return -1;
     }
     glfwWindowHint(GLFW_SAMPLES, 4);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
     GLFWmonitor* monitor = glfwGetPrimaryMonitor();
     WINDOW = glfwCreateWindow(1400, 1050, "OpenStrategia", monitor, nullptr);

--- a/RenderObject.hpp
+++ b/RenderObject.hpp
@@ -67,24 +67,11 @@ public:
      */
     virtual ~RenderObject();
 protected:
-    /**
-     * \brief Structure used to draw the RenderObject indirectly.
-     */
-    typedef struct DrawElementsIndirectCommand_t
-    {
-        GLuint  elementCount; /**< Number of vertices single object has. */
-        GLuint  primCount; /**< Number of instances of the object to draw. Leave 1 unless you know what you are doing. */
-        GLuint  firstIndex; /**< Index starting offset. Leave 0 unless you know what you are doing. */
-        GLuint  baseVertex; /**< Vertex starting offset. Leave 0 unless you know what you are doing. */
-        GLuint  baseInstance;/**< Instance starting offset. Leave 0 unless you know what you are doing. */
-    } DrawElementsIndirectCommand;
-
     Texture* texture; /**< Surface texture of the object. */
     GLuint VBO; /**< Index of the vertex GL_ARRAY_BUFFER. */
     GLuint UVBO; /**< Index of the UV coordinates GL_ARRAY_BUFFER. */
     GLuint EBO; /**< Index of the GL_ELEMENT_ARRAY_BUFFER. */
-    GLuint IBO; /**< Index of the GL_DRAW_INDIRECT_BUFFER. */
-    DrawElementsIndirectCommand* indirectData;  /**< Command structure used to draw the RenderObject indirectly. */
+    GLuint elementCount; /**< Number of elements single object has. */
 };
 
  #endif // RENDEROBJECT_HPP

--- a/RenderObject2D.cpp
+++ b/RenderObject2D.cpp
@@ -14,7 +14,7 @@ RenderObject2D::RenderObject2D()        //DEBUG ONLY
 	glBufferData(GL_ARRAY_BUFFER, sizeof(vertex_buffer_data), vertex_buffer_data, GL_STATIC_DRAW);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
 	glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(element_buffer_data), element_buffer_data, GL_STATIC_DRAW);
-	indirectData->elementCount = 3;
+	elementCount = 3;
 }
 
 RenderObject2D::RenderObject2D(std::vector<GLfloat>* vertexData, std::vector<GLuint>* indexData) : RenderObject(vertexData, indexData) {}

--- a/RenderObject3D.cpp
+++ b/RenderObject3D.cpp
@@ -20,7 +20,7 @@ RenderObject3D::RenderObject3D() : NBO(0)                   //DEBUG ONLY
 	glBufferData(GL_ARRAY_BUFFER, sizeof(vertex_buffer_data), vertex_buffer_data, GL_STATIC_DRAW);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
 	glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(element_buffer_data), element_buffer_data, GL_STATIC_DRAW);
-	indirectData->elementCount = 36;
+	elementCount = 36;
 }
 
 RenderObject3D::RenderObject3D(const RenderObject3D& other) : RenderObject(other), NBO(0)
@@ -136,7 +136,7 @@ RenderObject3D::RenderObject3D(std::string ObjectName) : RenderObject(), NBO(0)
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, vertexIndices.size() * sizeof(GLuint), vertexIndices.data(), GL_STATIC_DRAW);
     glBindBuffer(GL_ARRAY_BUFFER, NBO);
     glBufferData(GL_ARRAY_BUFFER, normals.size() * sizeof(vec3), normals.data(), GL_STATIC_DRAW);
-    indirectData->elementCount = vertexIndices.size();
+    elementCount = vertexIndices.size();
 }
 
 void RenderObject3D::render(const Program* const shaders, const Camera* const cam) const

--- a/bin/Release/shaders/basic.fragment.glsl
+++ b/bin/Release/shaders/basic.fragment.glsl
@@ -1,4 +1,4 @@
-#version 400 core
+#version 330 core
 
 in vec4 vColor;
 

--- a/bin/Release/shaders/basic.vertex.glsl
+++ b/bin/Release/shaders/basic.vertex.glsl
@@ -1,4 +1,4 @@
-#version 400 core
+#version 330 core
 
 layout(location = 0) in vec4 vPosition_m;
 layout(location = 1) in vec4 vNormal_m;

--- a/bin/Release/shaders/blinn.fragment.glsl
+++ b/bin/Release/shaders/blinn.fragment.glsl
@@ -1,4 +1,4 @@
-#version 400 core
+#version 330 core
 
 in vec4 vNormal_w;
 in vec4 vToLight_w;

--- a/bin/Release/shaders/blinn.vertex.glsl
+++ b/bin/Release/shaders/blinn.vertex.glsl
@@ -1,4 +1,4 @@
-#version 400 core
+#version 330 core
 
 layout(location = 0) in vec4 vPosition_m;
 layout(location = 2) in vec4 vNormal_m;

--- a/bin/Release/shaders/phong.fragment.glsl
+++ b/bin/Release/shaders/phong.fragment.glsl
@@ -1,4 +1,4 @@
-#version 400 core
+#version 330 core
 
 in vec4 vNormal_w;
 in vec4 vToCamera_w;

--- a/bin/Release/shaders/phong.vertex.glsl
+++ b/bin/Release/shaders/phong.vertex.glsl
@@ -1,4 +1,4 @@
-#version 400 core
+#version 330 core
 
 layout(location = 0) in vec4 vPosition_m;
 layout(location = 1) in vec2 vUV;


### PR DESCRIPTION
RenderObject isn't drawn indirectly anymore.
OpenGL 3.3 is required now, instead of OpenGL 4.0
